### PR TITLE
read the $HOME/.my.cnf with password by default

### DIFF
--- a/rotatebinlogs.pl
+++ b/rotatebinlogs.pl
@@ -114,7 +114,7 @@ EOF
 ## Lower process priority to have a bit less impact on running system.
 nice($priority);
 
-my $dbh = DBI->connect("DBI:mysql:database=mysql;host=$host;port=$port", $user, $pass) || die("Couldn't connect: $!");
+my $dbh = DBI->connect("DBI:mysql:database=mysql;host=$host;port=$port;mysql_read_default_file=$ENV{HOME}/.my.cnf", $user, $pass) || die("Couldn't connect: $!");
 
 print "Grabbing master status\n";
 my $status = $dbh->selectrow_hashref("SHOW MASTER STATUS");


### PR DESCRIPTION
I don't know perl too much and also I agree that this "hack" is not too much pretty but it seems that following code works in the situation when:
- the $HOME/.my.cnf file doesn't exist and you specify the username and password 
- the $HOME/.my.cnf file exists but nothing is inside
- when you don't specify username and password
- when both options are specified then the --user --pass options are prefered
